### PR TITLE
第八章: 実装を隠す

### DIFF
--- a/src/dollar.test.ts
+++ b/src/dollar.test.ts
@@ -2,14 +2,18 @@ import { Dollar } from './dollar';
 
 describe('DollarTest', () => {
   it('multiplication', () => {
-    const five: Dollar = new Dollar(5);
-    expect(five.times(2).equals(new Dollar(10))).toBe(true);
-    expect(five.times(3).equals(new Dollar(15))).toBe(true);
+    const five: Dollar = Dollar.createInstance(5);
+    expect(five.times(2).equals(Dollar.createInstance(10))).toBe(true);
+    expect(five.times(3).equals(Dollar.createInstance(15))).toBe(true);
     // クラス同士の比較は、equalsメソッドを経由して行う必要がある
     // ref: https://jestjs.io/docs/expect#toequalvalue
   });
   it('equals', () => {
-    expect(new Dollar(5).equals(new Dollar(5))).toBe(true);
-    expect(new Dollar(5).equals(new Dollar(6))).toBe(false);
+    expect(Dollar.createInstance(5).equals(Dollar.createInstance(5))).toBe(
+      true
+    );
+    expect(Dollar.createInstance(5).equals(Dollar.createInstance(6))).toBe(
+      false
+    );
   });
 });

--- a/src/dollar.ts
+++ b/src/dollar.ts
@@ -1,8 +1,12 @@
 import { Money } from './money';
 
 export class Dollar extends Money {
-  constructor(amount: number) {
+  private constructor(amount: number) {
     super(amount);
+  }
+
+  static createInstance(amount: number): Dollar {
+    return new Dollar(amount);
   }
 
   public times = (multiplier: number): Dollar => {

--- a/src/franc.test.ts
+++ b/src/franc.test.ts
@@ -1,16 +1,15 @@
-import { Dollar } from './dollar';
 import { Franc } from './franc';
 
 describe('FrancTest', () => {
   it('multiplication', () => {
-    const five: Franc = new Franc(5);
-    expect(five.times(2).equals(new Franc(10))).toBe(true);
-    expect(five.times(3).equals(new Franc(15))).toBe(true);
+    const five: Franc = Franc.createInstance(5);
+    expect(five.times(2).equals(Franc.createInstance(10))).toBe(true);
+    expect(five.times(3).equals(Franc.createInstance(15))).toBe(true);
     // クラス同士の比較は、equalsメソッドを経由して行う必要がある
     // ref: https://jestjs.io/docs/expect#toequalvalue
   });
   it('equals', () => {
-    expect(new Franc(5).equals(new Franc(5))).toBe(true);
-    expect(new Franc(5).equals(new Franc(6))).toBe(false);
+    expect(Franc.createInstance(5).equals(Franc.createInstance(5))).toBe(true);
+    expect(Franc.createInstance(5).equals(Franc.createInstance(6))).toBe(false);
   });
 });

--- a/src/franc.ts
+++ b/src/franc.ts
@@ -1,8 +1,12 @@
 import { Money } from './money';
 
 export class Franc extends Money {
-  constructor(amount: number) {
+  private constructor(amount: number) {
     super(amount);
+  }
+
+  static createInstance(amount: number): Franc {
+    return new Franc(amount);
   }
 
   public times = (multiplier: number): Franc => {

--- a/src/money.test.ts
+++ b/src/money.test.ts
@@ -3,6 +3,8 @@ import { Franc } from './franc';
 
 describe('MoneyTest', () => {
   it('equals', () => {
-    expect(new Franc(5).equals(new Dollar(5))).toBe(false);
+    expect(Franc.createInstance(5).equals(Dollar.createInstance(5))).toBe(
+      false
+    );
   });
 });

--- a/src/money.ts
+++ b/src/money.ts
@@ -1,8 +1,14 @@
 export abstract class Money {
   protected amount: number;
-  constructor(amount: number) {
+  protected constructor(amount: number) {
     this.amount = amount;
   }
+
+  // memo: createInstanceっていうabstractでstaticな関数作りたいけど作れない。。
+  // ref: https://github.com/microsoft/TypeScript/issues/34516
+
+  abstract times(multiplier: number): Money;
+
   public equals = (money: Money): boolean => {
     return this.amount === money.amount && this.compareInstance(money);
   };


### PR DESCRIPTION
# やったこと
- timesメソッドの重複を除去できるように、まずはabstractで抽象度を揃えた
- インスタンス生成を親に揃えろってあったけど、なんか無理みな気がしたから、まずはcreateInstanceっていう関数でinitialize処理を揃えた
  - なので、まだ正直サブクラスを隠せてはいない

# 感じたこと
- JavaとTypeScriptでできることできないことの差がはっきりと現れ始めた。。
  - 親クラスからサブクラス参照しようとすると、できるはできるんだけど、循環参照になってしまう
  - `TypeError: Class extends value undefined is not a constructor or null`
  - で、テストが失敗する
  - これってなんかJavaでもできるイメージないけど、どうなんだろう。。